### PR TITLE
0.2.0 - smoke tests and engine improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
-
-## [0.0.1] - 2022-01-05
+## [0.2.0] - 2022-01-07
+###Added
+- Added additional smoke tests to better validate CyclopsEngine.Immediate.Add() functionality.
+- Added CyclopsEngine.MaxNestingDepth and supporting code to limit Immediate.Add() enqueuing per frame... not exactly recursive, but similar idea.
+###Changed
+- Refactored CyclopsEngine error handling events.
+###Fixed
+- Fixed queuing issues with CyclopsEngine.Immediate.Add() which itself is new to the Framework.  New smoke tests caught this issue.
+## [0.1.1] - 2022-01-06
+###Fixed
+- Fixed documentation issues.
+## [0.1.0] - 2022-01-05
 ###Added
 - This is the beginning of an effort to upgrade and refactor Cyclops Framework as a Unity package.

--- a/Runtime/Core/CyclopsCommon.cs
+++ b/Runtime/Core/CyclopsCommon.cs
@@ -36,7 +36,7 @@ namespace Smonch.CyclopsFramework
         public const string Tag_Loop = TagPrefix_Cyclops + "Loop";
         public const string Tag_LoopWhile = TagPrefix_Cyclops + "LoopWhile";
         public const string Tag_Sentinel = TagPrefix_Cyclops + "Sentinel";
-
+        
         /// <summary>
         /// This provides a reference to the CyclopsEngine host.
         /// </summary>

--- a/Runtime/Core/CyclopsRoutine.cs
+++ b/Runtime/Core/CyclopsRoutine.cs
@@ -40,6 +40,8 @@ namespace Smonch.CyclopsFramework
         /// </summary>
         private Action FailureHandler { get; set; }
         
+        internal int NestingDepth { get; set; }
+
         /// <summary>
         /// This is used by CyclopsEngine and provides a way to skip adding this routine to the active queue if the specified condition is met.
         /// If needed, use CyclopsCommon.SkipIf to provide a condition.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.smonch.cyclopsframework",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "displayName": "Cyclops Framework",
   "description": "Cyclops Framework provides a tag-based approach to simplifying state management, asynchronous routines, messaging, and tweening.  It plays well with others, drops nicely into existing projects, and you can use as much or little of it as you like.\n\nBut why?\n\nImagine that you have several coroutine sequences running in parallel and you don't know how long they'll take to complete.\n\nWhat if you could tag these sequences and then stop or pause them by tag?\nWhat if you wanted to insert cascading tags at various points in a sequence?\nWhat if a sequence is shaped like a tree?\nWhat if you could use as many tags as you like and decide which tags should cascade and which tags shouldn't?\nWhat if your coroutines provided state management events such as OnEnter, OnExit, and OnUpdate?\nWhat if these coroutines could repeat for a number of cycles and provide cycle specific events such as OnFirstFrame and OnLastFrame?\nWhat if you could send messages by tag to anything you'd like, no receiver required?\n\nCyclops Framework was built for these types of situations.  Usage should lead to greater flexibility with less code written.",
   "unity": "2019.4",


### PR DESCRIPTION
Added additional smoke tests to better validate CyclopsEngine.Immediate.Add() functionality.
Added CyclopsEngine.MaxNestingDepth and supporting code to limit Immediate.Add() enqueuing per frame... not exactly recursive, but similar idea.
Refactored CyclopsEngine error handling events.
Fixed queuing issues with CyclopsEngine.Immediate.Add() which itself is new to the Framework.  New smoke tests caught this issue.