### PR TITLE
0.4.0 - Added 2 smoke tests. Fixed pausing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [0.4.0] - 2022-01-19
+- Added two pause and resume smoke tests with several variants each.
+- Fixed pause and resume functionality was unintentionally disabled during the refactoring process.  Caught this with the new smoke tests.  It's working properly now.
+- Changed pooling data structures used for collections within CyclopsRoutine.  Queue was replaced with ConcurrentBag for improved thread safety.  The main thread is still the primary use case and that's what ConcurrentBag is optimized for... no locking overhead.  Note: It's likely that built-in pooling functionality will be added to CyclopsRoutine in order to minimize allocations and garbage collection.
+- Changed several routines that still weren't using const string Tag.  They are now.
+- Changed several CyclopsCommon sugar methods were returning a CyclopsRoutine.  They now return their specific type.  This provides transparency and will automatically expose any unique functionality those classes may have now or in the future.
 ## [0.3.0] - 2022-01-09
 ###Changed
 - Removed CyclopsEngine sentinel code.  It was used to maintain proper order in status reports but isn't really needed.

--- a/Runtime/Core/CyclopsCommon.cs
+++ b/Runtime/Core/CyclopsCommon.cs
@@ -179,14 +179,14 @@ namespace Smonch.CyclopsFramework
             return true;
         }
  
-		public CyclopsRoutine Add(Action f)
+		public CyclopsLambda Add(Action f)
         {
             return Add(new CyclopsLambda(f));
         }
 
-        public CyclopsRoutine Add(string tag, Action f)
+        public CyclopsLambda Add(string tag, Action f)
         {
-            return Add(new CyclopsLambda(f))
+            return (CyclopsLambda)Add(new CyclopsLambda(f))
                 .AddTag(tag);
         }
 
@@ -239,19 +239,19 @@ namespace Smonch.CyclopsFramework
             return AddSequence(routines, false);
         }
 
-        public CyclopsRoutine Loop(Action f)
+        public CyclopsLambda Loop(Action f)
         {
-            return Add(new CyclopsLambda(period: 0f, cycles: float.MaxValue, f))
+            return (CyclopsLambda)Add(new CyclopsLambda(period: 0f, cycles: float.MaxValue, f))
                 .AddTag(Tag_Loop);
         }
 
-        public CyclopsRoutine Loop(float period, float cycles, Action f)
+        public CyclopsLambda Loop(float period, float cycles, Action f)
         {
-            return Add(new CyclopsLambda(period, cycles, f))
+            return (CyclopsLambda)Add(new CyclopsLambda(period, cycles, f))
                 .AddTag(Tag_Loop);
         }
 
-        public CyclopsRoutine LoopWhile(Func<bool> predicate, float period = 0f)
+        public CyclopsLambda LoopWhile(Func<bool> predicate, float period = 0f)
         {
             var routine = Add(new CyclopsLambda(period, float.MaxValue, () =>
             {
@@ -259,10 +259,10 @@ namespace Smonch.CyclopsFramework
                     Context.Stop();
             })).AddTag(Tag_LoopWhile);
 
-            return routine;
+            return (CyclopsLambda)routine;
         }
 
-        public CyclopsRoutine LoopWhile(Func<bool> whilePredicate, Action whileBody, float period = 0f)
+        public CyclopsLambda LoopWhile(Func<bool> whilePredicate, Action whileBody, float period = 0f)
         {
             var routine = Add(new CyclopsLambda(period, float.MaxValue, () =>
             {
@@ -279,7 +279,7 @@ namespace Smonch.CyclopsFramework
                 }
             })).AddTag(Tag_LoopWhile);
 
-            return routine;
+            return (CyclopsLambda)routine;
         }
 
         public CyclopsRoutine Nop(string tag = null, int cycles=1)
@@ -300,12 +300,12 @@ namespace Smonch.CyclopsFramework
             return Context;
         }
         
-        public CyclopsRoutine Sleep(float period, string tag=null)
+        public CyclopsSleep Sleep(float period, string tag=null)
         {
             if (tag == null)
                 return Add(new CyclopsSleep(period));
             else
-                return Add(new CyclopsSleep(period)).AddTag(tag);
+                return (CyclopsSleep)Add(new CyclopsSleep(period)).AddTag(tag);
         }
 
         public CyclopsWaitForMessage Listen(string receiverTag, string messageName)
@@ -318,32 +318,32 @@ namespace Smonch.CyclopsFramework
             return Add(new CyclopsWaitForMessage(receiverTag, messageName, timeout, cycles));
         }
         
-        public CyclopsRoutine WaitForTask(Action<CyclopsTask> f)
+        public CyclopsTask WaitForTask(Action<CyclopsTask> f)
         {
             return Add(new CyclopsTask(f));
         }
 
-        public CyclopsRoutine WaitUntil(Func<bool> condition)
+        public CyclopsWaitUntil WaitUntil(Func<bool> condition)
         {
             return Add(new CyclopsWaitUntil(condition));
         }
 
-        public CyclopsRoutine WaitUntil(Func<bool> condition, float timeout)
+        public CyclopsWaitUntil WaitUntil(Func<bool> condition, float timeout)
         {
             return Add(new CyclopsWaitUntil(condition, timeout));
         }
 
-        public CyclopsRoutine When(Func<bool> condition, Action response = null, float timeout = float.MaxValue)
+        public CyclopsWhen When(Func<bool> condition, Action response = null, float timeout = float.MaxValue)
         {
             return Add(new CyclopsWhen(condition, response, timeout));
         }
         
-        public CyclopsRoutine Lerp(float period, float cycles, Action<float> f)
+        public CyclopsUpdate Lerp(float period, float cycles, Action<float> f)
         {
             return Add(new CyclopsUpdate(period, cycles, null, f));
         }
 
-        public CyclopsRoutine Lerp(float period, Action<float> f)
+        public CyclopsUpdate Lerp(float period, Action<float> f)
         {
             return Add(new CyclopsUpdate(period, 1, null, f));
         }

--- a/Runtime/Core/CyclopsEngine.cs
+++ b/Runtime/Core/CyclopsEngine.cs
@@ -399,14 +399,20 @@ namespace Smonch.CyclopsFramework
             while (_routines.Count > 0)
             {
                 var routine = _routines.Dequeue();
-
-                Context = routine;
+                
                 _finishedRoutines.Enqueue(routine);
-                routine.Update(deltaTime);
 
-                // The possibility of an infinite loop caused by nesting Immediately.Add() has passed
-                // unless someone goes out of their way to modify NestingDepth... don't do that.
-                routine.NestingDepth = 0;
+                // Note: If paused routines were removed from this list and added to a holding collection like say a HashSet,
+                // they'd typically lose their position in the queue when later resumed.  Deterministic ordering is a nice thing to have.
+                if (!routine.IsPaused)
+                {
+                    Context = routine;
+                    routine.Update(deltaTime);
+
+                    // The possibility of an infinite loop caused by nesting Immediately.Add() has passed
+                    // unless someone goes out of their way to modify NestingDepth... don't do that.
+                    routine.NestingDepth = 0;
+                }
             }
 
             Context = null;

--- a/Runtime/Routines/Flow/CyclopsCoroutine.cs
+++ b/Runtime/Routines/Flow/CyclopsCoroutine.cs
@@ -21,15 +21,9 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsCoroutine : CyclopsRoutine
     {
-        public static readonly string Tag = TagPrefix_Cyclops + "CyclopsCoroutine";
+        public const string Tag = TagPrefix_Cyclops + "CyclopsCoroutine";
 
         Func<IEnumerator> _f;
-
-        //public CyclopsCoroutine Instantiate(double.MaxValue, 1, null, Tag)
-        //{
-        //    UnityEngine.Pool.ObjectPool<CyclopsCoroutine>.Get(out var instance);
-
-        //}
         
         public CyclopsCoroutine(Func<IEnumerator> f)
             : base(double.MaxValue, 1, null, Tag)

--- a/Runtime/Routines/Flow/CyclopsIterate.cs
+++ b/Runtime/Routines/Flow/CyclopsIterate.cs
@@ -21,7 +21,7 @@ namespace Smonch.CyclopsFramework
 {
 	public class CyclopsIterate<T> : CyclopsRoutine
     {
-        public static readonly string Tag = TagPrefix_Cyclops + "CyclopsIterate";
+        public const string Tag = TagPrefix_Cyclops + "CyclopsIterate";
 		
 		IEnumerable<T> _collection;
 		int _maxSuccessesPerFrame;

--- a/Runtime/Routines/Flow/CyclopsLambda.cs
+++ b/Runtime/Routines/Flow/CyclopsLambda.cs
@@ -20,7 +20,7 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsLambda : CyclopsRoutine
     {
-        public static readonly string Tag = TagPrefix_Cyclops + "CyclopsLambda";
+        public const string Tag = TagPrefix_Cyclops + "CyclopsLambda";
 		
 		private object _data;
 

--- a/Runtime/Routines/Flow/CyclopsSleep.cs
+++ b/Runtime/Routines/Flow/CyclopsSleep.cs
@@ -18,7 +18,7 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsSleep:CyclopsRoutine
     {
-        public static readonly string Tag = TagPrefix_Cyclops + "CyclopsSleep";
+        public const string Tag = TagPrefix_Cyclops + "CyclopsSleep";
 		
         public CyclopsSleep(double period)
             : base(period, 1, null, Tag)

--- a/Runtime/Routines/Flow/CyclopsUpdate.cs
+++ b/Runtime/Routines/Flow/CyclopsUpdate.cs
@@ -20,7 +20,7 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsUpdate : CyclopsRoutine
     {
-        public static readonly string Tag = TagPrefix_Cyclops + "CyclopsUpdate";
+        public const string Tag = TagPrefix_Cyclops + "CyclopsUpdate";
 
         Action _f = null;
 		Action<float>_ft = null;

--- a/Runtime/Routines/Flow/CyclopsWaitForMessage.cs
+++ b/Runtime/Routines/Flow/CyclopsWaitForMessage.cs
@@ -20,7 +20,7 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsWaitForMessage : CyclopsRoutine, ICyclopsMessageInterceptor
     {
-        public static readonly string Tag = TagPrefix_Cyclops + "CyclopsWaitForMessage";
+        public const string Tag = TagPrefix_Cyclops + "CyclopsWaitForMessage";
 
         private string _messageName = null;
         private bool _timedOut = true;

--- a/Runtime/Routines/Flow/CyclopsWaitUntil.cs
+++ b/Runtime/Routines/Flow/CyclopsWaitUntil.cs
@@ -20,7 +20,7 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsWaitUntil : CyclopsRoutine
     {
-        public static readonly string Tag = TagPrefix_Cyclops + "CyclopsWaitUntil";
+        public const string Tag = TagPrefix_Cyclops + "CyclopsWaitUntil";
 		
         Func<bool> _f;
 

--- a/Runtime/Routines/Flow/CyclopsWhen.cs
+++ b/Runtime/Routines/Flow/CyclopsWhen.cs
@@ -20,7 +20,7 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsWhen : CyclopsRoutine
     {
-        public static readonly string Tag = TagPrefix_Cyclops + "CyclopsWhen";
+        public const string Tag = TagPrefix_Cyclops + "CyclopsWhen";
 
         Func<bool> _f;
 		Action _g;

--- a/Tests/Runtime/CyclopsEngineTests.cs
+++ b/Tests/Runtime/CyclopsEngineTests.cs
@@ -142,6 +142,75 @@ namespace Smonch.CyclopsFramework
 
         [Test]
         [Category("Smoke")]
+        [Category("Pausing")]
+        public void Pause_WithValidTag_DecrementsToOne(
+            [Values(ValidTag)] string tag,
+            [Values(1,2,3,4,5)] int cycles,
+            [Values(MaxDeltaTime)] float deltaTime)
+        {
+            int x = 2;
+
+            Host.Loop(period: 0, cycles: 2, () => --x)
+                .AddTag(tag);
+
+            // Get this thing added at the end of this frame and ready for update on the next frame.
+            Host.Update(deltaTime);
+            
+            Assert.AreEqual(2, x);
+            
+            Host.Pause(tag);
+
+            for (int i = 0; i < cycles; ++i)
+            {
+                // Should only update the CyclopsLambda once.
+                Host.Update(deltaTime);
+                Assert.AreEqual(1, x);
+            }
+        }
+
+        [Test]
+        [Category("Smoke")]
+        [Category("Pausing")]
+        public void PauseAndResume_WithValidTag_DecrementsToZero(
+            [Values(ValidTag)] string tag,
+            [Values(1, 2, 3, 4, 5)] int cycles,
+            [Values(MaxDeltaTime)] float deltaTime)
+        {
+            int x = 2;
+            int y = cycles;
+
+            Host.Loop(period: 0, cycles: 2, () => --x)
+                .AddTag(tag);
+            Host.Loop(period: 0, cycles: cycles, () => --y);
+
+            // Get these routines added at the end of this frame and ready for update on the next frame.
+            Host.Update(deltaTime);
+            
+            Assert.AreEqual(2, x);
+
+            Host.Pause(tag);
+
+            for (int i = 0; i < cycles; ++i)
+            {
+                // Should only update the CyclopsLambda once.
+                Host.Update(deltaTime);
+                Assert.AreEqual(1, x);
+            }
+
+            Host.Resume(tag);
+
+            // Resumes after all updates are processed.
+            Host.Update(deltaTime);
+
+            // Actually updates on the next frame.
+            Host.Update(deltaTime);
+
+            Assert.Zero(x);
+            Assert.Zero(y);
+        }
+
+        [Test]
+        [Category("Smoke")]
         [Category("Updates")]
         public void UpdateLambda_WithValidDeltaTime_DecrementsToZero(
             [ValueSource(nameof(ValidDeltaTimes))] float deltaTime)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.smonch.cyclopsframework",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "displayName": "Cyclops Framework",
   "description": "Cyclops Framework provides a tag-based approach to simplifying state management, asynchronous routines, messaging, and tweening.  It plays well with others, drops nicely into existing projects, and you can use as much or little of it as you like.\n\nBut why?\n\nImagine that you have several coroutine sequences running in parallel and you don't know how long they'll take to complete.\n\nWhat if you could tag these sequences and then stop or pause them by tag?\nWhat if you wanted to insert cascading tags at various points in a sequence?\nWhat if a sequence is shaped like a tree?\nWhat if you could use as many tags as you like and decide which tags should cascade and which tags shouldn't?\nWhat if your coroutines provided state management events such as OnEnter, OnExit, and OnUpdate?\nWhat if these coroutines could repeat for a number of cycles and provide cycle specific events such as OnFirstFrame and OnLastFrame?\nWhat if you could send messages by tag to anything you'd like, no receiver required?\n\nCyclops Framework was built for these types of situations.  Usage should lead to greater flexibility with less code written.",
   "unity": "2019.4",


### PR DESCRIPTION
Added - Created two pause and resume smoke tests with several variants each.
Fixed - Pause and resume functionality was unintentionally disabled during the refactoring process.  Caught this with the new smoke tests.  It's working properly now.
Changed - CyclopsRoutine now uses ConcurrentBag based memory pooling for improved thread safety.  Main thread is still the primary use case and that's what ConcurrentBag is optimized for... no locking overhead.
Changed - Several routines still weren't using const string Tag.  They are now.
Changed - Several CyclopsCommon sugar methods were returning a CyclopsRoutine.  They now return their specific type.  This provides transparency and will automatically expose any unique functionality those classes may have now or in the future.