### PR TITLE
Removed default tags. Improved timers.

### DIFF
--- a/Runtime/Core/CyclopsCommon.cs
+++ b/Runtime/Core/CyclopsCommon.cs
@@ -1,6 +1,6 @@
 ﻿// Cyclops Framework
 // 
-// Copyright 2010 - 2022 Mark Davis
+// Copyright 2010 - 2023 Mark Davis
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,19 +20,10 @@ namespace Smonch.CyclopsFramework
 {
     public abstract class CyclopsCommon
     {
-        public const float MaxDeltaTime = .25f;
-        public const string MessagePrefix_Cyclops = "Cyclops";
-        public const string Message_Analytics = MessagePrefix_Cyclops + "Analytics";
-        public const string TagAttributeDelimiter = ":";
-        public const string TagPrefix_Attribute = "@";
-        public const string TagPrefix_Noncascading = "!";
-        public const string TagPrefix_Cyclops = "!cf.";
         public const string Tag_All = "*";
-        public const string Tag_Logging = TagPrefix_Cyclops + "Logging";
-        public const string Tag_Nop = TagPrefix_Cyclops + "Nop";
-        public const string Tag_Undefined = TagPrefix_Cyclops + "Undefined";
-        public const string Tag_Loop = TagPrefix_Cyclops + "Loop";
-        public const string Tag_LoopWhile = TagPrefix_Cyclops + "LoopWhile";
+        public const string Tag_Log = "Cyclops.Log";
+        public const string TagPrefix_Noncascading = "!";
+        public const float MaxDeltaTime = .25f;
         
         public CyclopsRoutine Context { get; protected set; }
         
@@ -149,12 +140,6 @@ namespace Smonch.CyclopsFramework
             if (o == null)
             {
                 reason = "ICyclopsTaggable.Tags must not be null.";
-                return false;
-            }
-
-            if (o.Tags.Count == 0)
-            {
-                reason = "ICyclopsTaggable.Tags must contain at least 1 tag.";
                 return false;
             }
 

--- a/Runtime/Core/CyclopsNext.cs
+++ b/Runtime/Core/CyclopsNext.cs
@@ -1,6 +1,6 @@
 ﻿// Cyclops Framework
 // 
-// Copyright 2010 - 2022 Mark Davis
+// Copyright 2010 - 2023 Mark Davis
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 using System;
+using System.Linq;
 using UnityEngine.Pool;
 
 namespace Smonch.CyclopsFramework
@@ -61,16 +62,11 @@ namespace Smonch.CyclopsFramework
         }
 
         public CyclopsLambda Loop(Action f)
-        {
-            return (CyclopsLambda)Add(CyclopsLambda.Instantiate(period: 0f, maxCycles: float.MaxValue, f))
-                .AddTag(Tag_Loop);
-        }
+            => (CyclopsLambda)Add(CyclopsLambda.Instantiate(period: 0f, maxCycles: float.MaxValue, f));
+        
 
         public CyclopsLambda Loop(float period, float maxCycles, Action f)
-        {
-            return (CyclopsLambda)Add(CyclopsLambda.Instantiate(period, maxCycles, f))
-                .AddTag(Tag_Loop);
-        }
+            => (CyclopsLambda)Add(CyclopsLambda.Instantiate(period, maxCycles, f));
 
         public CyclopsLambda LoopWhile(Func<bool> predicate, float period = 0f)
         {
@@ -78,7 +74,7 @@ namespace Smonch.CyclopsFramework
             {
                 if (!predicate())
                     Context.Stop();
-            })).AddTag(Tag_LoopWhile);
+            }));
 
             return (CyclopsLambda)routine;
         }
@@ -98,7 +94,7 @@ namespace Smonch.CyclopsFramework
                 {
                     Context.Stop();
                 }
-            })).AddTag(Tag_LoopWhile);
+            }));
 
             return (CyclopsLambda)routine;
         }
@@ -115,48 +111,29 @@ namespace Smonch.CyclopsFramework
             return nop;
         }
 
-        public CyclopsSleep Sleep(float period, string tag = null)
-        {
-            if (tag == null)
-                return Add(CyclopsSleep.Instantiate(period));
-            else
-                return (CyclopsSleep)Add(CyclopsSleep.Instantiate(period)).AddTag(tag);
-        }
+        public CyclopsSleep Sleep(double period)
+            => Add(CyclopsSleep.Instantiate(period));
 
         public CyclopsWaitForMessage Listen(string receiverTag, string messageName)
-        {
-            return Add(CyclopsWaitForMessage.Instantiate(receiverTag, messageName));
-        }
+            => Add(CyclopsWaitForMessage.Instantiate(receiverTag, messageName));
 
-        public CyclopsWaitForMessage Listen(string receiverTag, string messageName, float timeout, float maxCycles = 1)
-        {
-            return Add(CyclopsWaitForMessage.Instantiate(receiverTag, messageName, timeout, maxCycles));
-        }
+        public CyclopsWaitForMessage Listen(string receiverTag, string messageName, double timeout, double maxCycles = 1)
+            => Add(CyclopsWaitForMessage.Instantiate(receiverTag, messageName, timeout, maxCycles));
 
         public CyclopsTask WaitForTask(Action<CyclopsTask> f)
-        {
-            return Add(CyclopsTask.Instantiate(f));
-        }
+            => Add(CyclopsTask.Instantiate(f));
 
         public CyclopsWaitUntil WaitUntil(Func<bool> condition)
-        {
-            return Add(CyclopsWaitUntil.Instantiate(condition));
-        }
+            => Add(CyclopsWaitUntil.Instantiate(condition));
 
-        public CyclopsWaitUntil WaitUntil(Func<bool> condition, float timeout)
-        {
-            return Add(CyclopsWaitUntil.Instantiate(condition, timeout));
-        }
+        public CyclopsWaitUntil WaitUntil(Func<bool> condition, double timeout)
+            => Add(CyclopsWaitUntil.Instantiate(condition, timeout));
 
-        public CyclopsWhen When(Func<bool> condition, Action response = null, float timeout = float.MaxValue)
-        {
-            return Add(CyclopsWhen.Instantiate(condition, response, timeout));
-        }
+        public CyclopsWhen When(Func<bool> condition, Action response = null, double timeout = double.MaxValue)
+            => Add(CyclopsWhen.Instantiate(condition, response, timeout));
 
-        public CyclopsUpdate Lerp(float period, float maxCycles, Action<float> f, Func<float, float> bias = null)
-        {
-            return Add(CyclopsUpdate.Instantiate(period, maxCycles, bias, f));
-        }
+        public CyclopsUpdate Lerp(double period, double maxCycles, Action<float> f, Func<float, float> bias = null)
+            => Add(CyclopsUpdate.Instantiate(period, maxCycles, bias, f));
 
         //public CyclopsWaitForMessage ProcessAnalytics(string tag, Action<CyclopsMessage> f, int maxCycles = 1, float timeout = float.MaxValue)
         //{
@@ -196,14 +173,14 @@ namespace Smonch.CyclopsFramework
             if (Logger == null)
             {
 #if (UNITY_EDITOR || DEVELOPMENT_BUILD)
-                return Add(tag: Tag_Logging, f: () => UnityEngine.Debug.Log(text));
+                return Add(tag: Tag_Log, f: () => UnityEngine.Debug.Log(text));
 #else
                 return Context;
 #endif
             }
             else
             {
-                return Add(tag: Tag_Logging, f: () => Logger?.Invoke(text));
+                return Add(tag: Tag_Log, f: () => Logger?.Invoke(text));
             }
         }
 
@@ -220,14 +197,14 @@ namespace Smonch.CyclopsFramework
             if (Logger == null)
             {
 #if (UNITY_EDITOR || DEVELOPMENT_BUILD)
-                return Add(tag: Tag_Logging, f: () => UnityEngine.Debug.Log(lazyPrinter()));
+                return Add(tag: Tag_Log, f: () => UnityEngine.Debug.Log(lazyPrinter()));
 #else
                 return Context;
 #endif
             }
             else
             {
-                return Add(tag: Tag_Logging, f: () => Logger?.Invoke(lazyPrinter()));
+                return Add(tag: Tag_Log, f: () => Logger?.Invoke(lazyPrinter()));
             }
         }
     }

--- a/Runtime/Core/ICyclopsTaggable.cs
+++ b/Runtime/Core/ICyclopsTaggable.cs
@@ -20,6 +20,6 @@ namespace Smonch.CyclopsFramework
 {
     public interface ICyclopsTaggable
     {
-        HashSet<string> Tags { get; }
+        IEnumerable<string> Tags { get; }
     }
 }

--- a/Runtime/Routines/Animation/TweenMaterialColor.cs
+++ b/Runtime/Routines/Animation/TweenMaterialColor.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenMaterialColor : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenMaterialColor);
-
         private Material _material;
         private int _propertyId;
         private Tween4c _tween;
@@ -36,7 +34,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenMaterialColor>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenMaterialColor>(period, cycles, bias);
 
             result._material = material;
             result._propertyId = propertyId;

--- a/Runtime/Routines/Animation/TweenMaterialFloat.cs
+++ b/Runtime/Routines/Animation/TweenMaterialFloat.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenMaterialFloat : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenMaterialFloat);
-
         private Material _material;
         private int _propertyId;
         private Tween1f _tween;
@@ -36,7 +34,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenMaterialFloat>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenMaterialFloat>(period, cycles, bias);
             
             result._material = material;
             result._propertyId = propertyId;

--- a/Runtime/Routines/Animation/TweenMaterialPropertyBlockColor.cs
+++ b/Runtime/Routines/Animation/TweenMaterialPropertyBlockColor.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenMaterialPropertyBlockColor : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenMaterialPropertyBlockColor);
-
         private MaterialPropertyBlock _block;
         private int _propertyId;
         private Tween4c _tween;
@@ -36,7 +34,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenMaterialPropertyBlockColor>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenMaterialPropertyBlockColor>(period, cycles, bias);
             
             result._block = block;
             result._propertyId = propertyId;

--- a/Runtime/Routines/Animation/TweenMaterialPropertyBlockFloat.cs
+++ b/Runtime/Routines/Animation/TweenMaterialPropertyBlockFloat.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenMaterialPropertyBlockFloat : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenMaterialPropertyBlockFloat);
-
         private MaterialPropertyBlock _block;
         private int _propertyId;
         private Tween1f _tween;
@@ -36,7 +34,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenMaterialPropertyBlockFloat>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenMaterialPropertyBlockFloat>(period, cycles, bias);
 
             result._block = block;
             result._propertyId = propertyId;

--- a/Runtime/Routines/Animation/TweenMaterialPropertyBlockVector.cs
+++ b/Runtime/Routines/Animation/TweenMaterialPropertyBlockVector.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenMaterialPropertyBlockVector : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenMaterialPropertyBlockVector);
-
         private MaterialPropertyBlock _block;
         private int _propertyId;
         private Tween4f _tween;
@@ -36,7 +34,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenMaterialPropertyBlockVector>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenMaterialPropertyBlockVector>(period, cycles, bias);
 
             result._block = block;
             result._propertyId = propertyId;

--- a/Runtime/Routines/Animation/TweenMaterialTextureOffset.cs
+++ b/Runtime/Routines/Animation/TweenMaterialTextureOffset.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenMaterialTextureOffset : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenMaterialTextureOffset);
-
         private Material _material;
         private int _nameId;
         private Tween2f _tween;
@@ -36,7 +34,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenMaterialTextureOffset>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenMaterialTextureOffset>(period, cycles, bias);
 
             result._material = material;
             result._nameId = nameId;

--- a/Runtime/Routines/Animation/TweenMaterialTextureScale.cs
+++ b/Runtime/Routines/Animation/TweenMaterialTextureScale.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenMaterialTextureScale : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenMaterialTextureScale);
-
         private Material _material;
         private int _nameId;
         private Tween2f _tween;
@@ -36,7 +34,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenMaterialTextureScale>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenMaterialTextureScale>(period, cycles, bias);
 
             result._material = material;
             result._nameId = nameId;

--- a/Runtime/Routines/Animation/TweenMaterialVector.cs
+++ b/Runtime/Routines/Animation/TweenMaterialVector.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenMaterialVector : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenMaterialVector);
-
         private Material _material;
         private int _propertyId;
         private Tween4f _tween;
@@ -36,7 +34,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenMaterialVector>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenMaterialVector>(period, cycles, bias);
 
             result._material = material;
             result._propertyId = propertyId;

--- a/Runtime/Routines/Animation/TweenTransformPosition.cs
+++ b/Runtime/Routines/Animation/TweenTransformPosition.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenTransformPosition : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenTransformPosition);
-
         private Transform _transform;
         private Tween3f _tween;
 
@@ -34,7 +32,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenTransformPosition>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenTransformPosition>(period, cycles, bias);
             
             result._transform = transform;
             result._tween.SetFromTo(fromPosition, toPosition);

--- a/Runtime/Routines/Animation/TweenTransformRotation.cs
+++ b/Runtime/Routines/Animation/TweenTransformRotation.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenTransformRotation : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenTransformRotation);
-
         private Transform _transform;
         private TweenQs _tween;
 
@@ -34,7 +32,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenTransformRotation>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenTransformRotation>(period, cycles, bias);
             
             result._transform = transform;
             result._tween.SetFromTo(fromRotation, toRotation);

--- a/Runtime/Routines/Animation/TweenTransformScale.cs
+++ b/Runtime/Routines/Animation/TweenTransformScale.cs
@@ -21,8 +21,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenTransformScale : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenTransformScale);
-
         private Transform _transform;
         private Tween3f _tween;
 
@@ -34,7 +32,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenTransformScale>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenTransformScale>(period, cycles, bias);
 
             result._transform = transform;
             result._tween.SetFromTo(fromScale, toScale);

--- a/Runtime/Routines/Audio/AudioRoutine.cs
+++ b/Runtime/Routines/Audio/AudioRoutine.cs
@@ -20,8 +20,6 @@ namespace Smonch.CyclopsFramework
 {
     public class AudioRoutine : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(AudioRoutine);
-
         private AudioSource _source;
         private bool _shouldRestoreAudioSourceSettings;
 
@@ -47,7 +45,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1f,
             bool shouldRestoreAudioSourceSettings = true)
         {
-            var result = InstantiateFromPool<AudioRoutine>(clip.length / pitch, cycles, bias:null, Tag);
+            var result = InstantiateFromPool<AudioRoutine>(clip.length / pitch, cycles, bias:null);
 
             result._source = source;
             result._currSettings.clip = clip;

--- a/Runtime/Routines/Audio/TweenAudioSourcePan.cs
+++ b/Runtime/Routines/Audio/TweenAudioSourcePan.cs
@@ -20,8 +20,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenAudioSourcePan : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenAudioSourcePan);
-
         private AudioSource _source;
         private Tween1f _tween;
 
@@ -33,7 +31,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             System.Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenAudioSourcePan>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenAudioSourcePan>(period, cycles, bias);
 
             result._source = source;
             result._tween.SetFromTo(fromPan, toPan);

--- a/Runtime/Routines/Audio/TweenAudioSourcePitch.cs
+++ b/Runtime/Routines/Audio/TweenAudioSourcePitch.cs
@@ -20,8 +20,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenAudioSourcePitch : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(TweenAudioSourcePitch);
-
         private AudioSource _source;
         private Tween1f _tween;
 
@@ -33,7 +31,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             System.Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenAudioSourcePitch>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenAudioSourcePitch>(period, cycles, bias);
 
             result._source = source;
             result._tween.SetFromTo(fromPitch, toPitch);

--- a/Runtime/Routines/Audio/TweenAudioSourceVolume.cs
+++ b/Runtime/Routines/Audio/TweenAudioSourceVolume.cs
@@ -20,8 +20,6 @@ namespace Smonch.CyclopsFramework
 {
     public class TweenAudioSourceVolume : CyclopsRoutine
     {
-        public static readonly string Tag = TagPrefix_Cyclops + nameof(TweenAudioSourceVolume);
-
         private AudioSource _source;
         private Tween1f _tween;
 
@@ -33,7 +31,7 @@ namespace Smonch.CyclopsFramework
             double cycles = 1,
             System.Func<float, float> bias = null)
         {
-            var result = InstantiateFromPool<TweenAudioSourceVolume>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<TweenAudioSourceVolume>(period, cycles, bias);
             
             result._source = source;
             result._tween.SetFromTo(fromVolume, toVolume);

--- a/Runtime/Routines/Flow/CyclopsLambda.cs
+++ b/Runtime/Routines/Flow/CyclopsLambda.cs
@@ -19,15 +19,12 @@ using System;
 namespace Smonch.CyclopsFramework
 {
     public class CyclopsLambda : CyclopsRoutine
-    {
-        public const string Tag = TagPrefix_Cyclops + nameof(CyclopsLambda);
-		
+    {	
 		private Action _f;
 
         public static CyclopsLambda Instantiate(Action f)
         {
-            var result = InstantiateFromPool<CyclopsLambda>(tag: Tag);
-
+            var result = InstantiateFromPool<CyclopsLambda>();
             result._f = f;
 
             return result;
@@ -35,8 +32,7 @@ namespace Smonch.CyclopsFramework
 
         public static CyclopsLambda Instantiate(double period, double maxCycles, Action f)
         {
-            var result = InstantiateFromPool<CyclopsLambda>(period, maxCycles, bias: null, tag: Tag);
-            
+            var result = InstantiateFromPool<CyclopsLambda>(period, maxCycles);
             result._f = f;
 
             return result;

--- a/Runtime/Routines/Flow/CyclopsNop.cs
+++ b/Runtime/Routines/Flow/CyclopsNop.cs
@@ -18,11 +18,9 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsNop : CyclopsRoutine
     {
-        public const string Tag = Tag_Nop;
-
         public static CyclopsNop Instantiate(double cycles)
         {
-            var result = InstantiateFromPool<CyclopsNop>(period: 0, cycles, tag: Tag);
+            var result = InstantiateFromPool<CyclopsNop>(period: 0, cycles);
             
             result.MustRecycleIfPooled = false;
 

--- a/Runtime/Routines/Flow/CyclopsSleep.cs
+++ b/Runtime/Routines/Flow/CyclopsSleep.cs
@@ -18,11 +18,9 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsSleep:CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(CyclopsSleep);
-		
         public static CyclopsSleep Instantiate(double period)
         {
-            var result = InstantiateFromPool<CyclopsSleep>(period, tag: Tag);
+            var result = InstantiateFromPool<CyclopsSleep>(period);
 
             result.MustRecycleIfPooled = false;
 

--- a/Runtime/Routines/Flow/CyclopsTask.cs
+++ b/Runtime/Routines/Flow/CyclopsTask.cs
@@ -23,8 +23,6 @@ namespace Smonch.CyclopsFramework
 {
     public sealed class CyclopsTask : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(CyclopsTask);
-        
         private Task _task;
         private CancellationTokenSource _tokenSource;
         private Action<CyclopsTask> _f;
@@ -38,7 +36,7 @@ namespace Smonch.CyclopsFramework
 
         public static CyclopsTask Instantiate(Task task, CancellationTokenSource tokenSource)
         {
-            var result = InstantiateFromPool<CyclopsTask>(tag: Tag);
+            var result = InstantiateFromPool<CyclopsTask>();
 
             result._task = task;
             result._tokenSource = tokenSource;
@@ -48,7 +46,7 @@ namespace Smonch.CyclopsFramework
 
         public static CyclopsTask Instantiate(Action<CyclopsTask> f)
         {
-            var result = InstantiateFromPool<CyclopsTask>(tag: Tag);
+            var result = InstantiateFromPool<CyclopsTask>();
             
             result._f = f;
 
@@ -57,7 +55,7 @@ namespace Smonch.CyclopsFramework
 
         public static CyclopsTask Instantiate(double period, double cycles, Action<CyclopsTask> f)
         {
-            var result = InstantiateFromPool<CyclopsTask>(period, cycles, tag: Tag);
+            var result = InstantiateFromPool<CyclopsTask>(period, cycles);
 
             result._f = f;
             

--- a/Runtime/Routines/Flow/CyclopsUpdate.cs
+++ b/Runtime/Routines/Flow/CyclopsUpdate.cs
@@ -20,8 +20,6 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsUpdate : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(CyclopsUpdate);
-
         private Action<float> _ft = null;
 
         public static CyclopsUpdate Instantiate(
@@ -30,7 +28,7 @@ namespace Smonch.CyclopsFramework
             Func<float, float> bias,
             Action<float> ft)
         {
-            var result = InstantiateFromPool<CyclopsUpdate>(period, cycles, bias, Tag);
+            var result = InstantiateFromPool<CyclopsUpdate>(period, cycles, bias);
             
             result._ft = ft;
             

--- a/Runtime/Routines/Flow/CyclopsWaitForMessage.cs
+++ b/Runtime/Routines/Flow/CyclopsWaitForMessage.cs
@@ -20,8 +20,6 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsWaitForMessage : CyclopsRoutine, ICyclopsMessageInterceptor
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(CyclopsWaitForMessage);
-
         private string _messageName = null;
         private bool _timedOut = true;
 
@@ -29,7 +27,7 @@ namespace Smonch.CyclopsFramework
 
         public static CyclopsWaitForMessage Instantiate(string receiverTag, string messageName)
         {
-            var result = InstantiateFromPool<CyclopsWaitForMessage>(double.MaxValue, tag: Tag);
+            var result = InstantiateFromPool<CyclopsWaitForMessage>(double.MaxValue);
 
             result._messageName = messageName;
             result.AddTag(receiverTag);
@@ -39,7 +37,7 @@ namespace Smonch.CyclopsFramework
 
         public static CyclopsWaitForMessage Instantiate(string receiverTag, string messageName, double timeout, double cycles)
         {
-            var result = InstantiateFromPool<CyclopsWaitForMessage>(timeout, cycles, tag: Tag);
+            var result = InstantiateFromPool<CyclopsWaitForMessage>(timeout, cycles);
             
             result._messageName = messageName;
             result.AddTag(receiverTag);

--- a/Runtime/Routines/Flow/CyclopsWaitUntil.cs
+++ b/Runtime/Routines/Flow/CyclopsWaitUntil.cs
@@ -20,14 +20,12 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsWaitUntil : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(CyclopsWaitUntil);
-		
         private Func<bool> _f;
         private bool _wasSuccessful;
 
         public static CyclopsWaitUntil Instantiate(Func<bool> f)
         {
-            var result = InstantiateFromPool<CyclopsWaitUntil>(double.MaxValue, tag: Tag);
+            var result = InstantiateFromPool<CyclopsWaitUntil>(double.MaxValue);
             
             result._f = f;
             
@@ -36,7 +34,7 @@ namespace Smonch.CyclopsFramework
 
         public static CyclopsWaitUntil Instantiate(Func<bool> f, double timeout)
         {
-            var result = InstantiateFromPool<CyclopsWaitUntil>(timeout, tag: Tag);
+            var result = InstantiateFromPool<CyclopsWaitUntil>(timeout);
 
             result._f = f;
             

--- a/Runtime/Routines/Flow/CyclopsWhen.cs
+++ b/Runtime/Routines/Flow/CyclopsWhen.cs
@@ -20,15 +20,13 @@ namespace Smonch.CyclopsFramework
 {
     public class CyclopsWhen : CyclopsRoutine
     {
-        public const string Tag = TagPrefix_Cyclops + nameof(CyclopsWhen);
-
         private Func<bool> _f;
         private Action _g;
         private bool _wasSuccessful = false;
 		
         public static CyclopsWhen Instantiate(Func<bool> f, Action g = null, double timeout = double.MaxValue)
         {
-            var result = InstantiateFromPool<CyclopsWhen>(timeout, tag: Tag);
+            var result = InstantiateFromPool<CyclopsWhen>(timeout);
 
             result._f = f;
             result._g = g;

--- a/Runtime/Routines/Messaging/CyclopsInterceptMessage.cs
+++ b/Runtime/Routines/Messaging/CyclopsInterceptMessage.cs
@@ -20,15 +20,13 @@ namespace Smonch.CyclopsFramework
 {
 	public class CyclopsInterceptMessage : CyclopsRoutine, ICyclopsMessageInterceptor
 	{
-		public static readonly string Tag = TagPrefix_Cyclops + nameof(CyclopsInterceptMessage);
-		
 		public delegate void Fd(CyclopsMessage msg);
 		
 		private Fd _fd;
 		
 		public static CyclopsInterceptMessage Instantiate(double period, double cycles, Fd f)
         {
-            var result = InstantiateFromPool<CyclopsInterceptMessage>(period, cycles, tag: Tag);
+            var result = InstantiateFromPool<CyclopsInterceptMessage>(period, cycles);
 			
 			result._fd = f;
 

--- a/Tests/Runtime/CyclopsEngineTests.cs
+++ b/Tests/Runtime/CyclopsEngineTests.cs
@@ -1,6 +1,6 @@
 // Cyclops Framework
 // 
-// Copyright 2010 - 2022 Mark Davis
+// Copyright 2010 - 2023 Mark Davis
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,20 +83,22 @@ namespace Smonch.CyclopsFramework
         public void Nop_WithDefaultTag_ExistsOnNextFrame(
             [Values(MaxDeltaTime)] float deltaTime)
         {
-            Host.Next.Nop();
+            string nopTag = nameof(CyclopsNop);
+
+            Host.Next.Nop(nopTag);
             Host.Update(deltaTime);
 
-            Assert.NotZero(Host.Count(CyclopsCommon.Tag_Nop));
+            Assert.NotZero(Host.Count(nopTag));
         }
 
         [Test]
         [Category("Smoke")]
         [Category("Tags")]
         public void Nop_WithDefaultTag_CountIsOneOnNextFrame(
-            [Values(CyclopsCommon.Tag_Nop)] string tag,
+            [Values(nameof(CyclopsNop))] string tag,
             [Values(MaxDeltaTime)] float deltaTime)
         {
-            Host.Next.Nop();
+            Host.Next.Nop(tag);
             Host.Update(deltaTime);
 
             Assert.NotZero(Host.Count(tag));


### PR DESCRIPTION
Default tags have a few quality of life benefits in testing and debugging.  That said, they're really not required and remain mostly unused.  Tags can be added as needed for testing.  Debugging will likely be updated to provide a view of both tags and class names. Timers were simplified and are now correctly removed when tag based removals are requested.  This was past behavior that didn't make it into the new framework until just now. TODO: Timers should be affected by pausing as well.  They were when they weren't special cased as they are now.