### PR TITLE
0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.8.1] - 2023-04-19
+
+- Added the missing 0.8.0 change log.
+- Fixed an issue with AnimationState in CyclopsAnimation where it was possible for AnimationState.speed to remain altered past its relationship with CyclopsAnimation.
+- Fixed a theorectical domain reloading issue with CyclopsRoutine's use of a static CyclopsPool. Even if domain reloading is disabled, the pool will still be properly reset.
+
+## [0.8.0] - 2023-04-16
+
+- Removed default tags despite a few benefits they provided for testing. Tags can be added as needed for testing. Debugging will likely be updated to provide a view of both tags and class names.
+- Simplified timers. They are now correctly removed when tag based removals are requested. This was past behavior that didn't make it into the new framework until just now.
+- TODO: Timers should be affected by pausing as well. They behaved as such before being special cased. They even took speed into account. Hmmm.
+
 ## [0.7.0] - 2023-04-10
 
 - Simplified: Removed constructors from all CyclopsRoutines in favor of using the public static Instantiate + InstantiateFromPool methods only.

--- a/Runtime/Game/CyclopsGame.cs
+++ b/Runtime/Game/CyclopsGame.cs
@@ -35,7 +35,7 @@ namespace Smonch.CyclopsFramework
             Manual
         }
 
-        protected CyclopsStateMachine StateMachine { get; private set; } = new CyclopsStateMachine();
+        protected CyclopsStateMachine StateMachine { get; } = new CyclopsStateMachine();
         public bool IsQuitting { get; private set; }
 
         public CyclopsGame() { }

--- a/Runtime/Routines/Animation/CyclopsAnimation.cs
+++ b/Runtime/Routines/Animation/CyclopsAnimation.cs
@@ -23,6 +23,10 @@ namespace Smonch.CyclopsFramework
         private Animation _animation;
         private AnimationState _state;
 
+        // Note: Unlike an operation on a transform where the intended goal is to leave the transform in an altered state,
+        // it might be a bit of a surprise if a previously stopped animation were left with an altered speed for the next playback.
+        private float _originalSpeed;
+
         public override bool IsPaused
         {
             get => base.IsPaused;
@@ -37,6 +41,7 @@ namespace Smonch.CyclopsFramework
 
             result._animation = animation;
             result._state = animation[clipName];
+            result._originalSpeed = result._state.speed;
 
             return result;
         }
@@ -70,6 +75,7 @@ namespace Smonch.CyclopsFramework
 
         protected override void OnExit()
         {
+            _state.speed = _originalSpeed;
             _animation.Stop(_state.name);
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.smonch.cyclopsframework",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "displayName": "Cyclops Framework",
   "description": "Cyclops Framework provides a tag-based approach to simplifying state management, asynchronous routines, messaging, and tweening.  It plays well with others, drops nicely into existing projects, and you can use as much or little of it as you like.\n\nBut why?\n\nImagine that you have several coroutine sequences running in parallel and you don't know how long they'll take to complete.\n\nWhat if you could tag these sequences and then stop or pause them by tag?\nWhat if you wanted to insert cascading tags at various points in a sequence?\nWhat if a sequence is shaped like a tree?\nWhat if you could use as many tags as you like and decide which tags should cascade and which tags shouldn't?\nWhat if your coroutines provided state management events such as OnEnter, OnExit, and OnUpdate?\nWhat if these coroutines could repeat for a number of cycles and provide cycle specific events such as OnFirstFrame and OnLastFrame?\nWhat if you could send messages by tag to anything you'd like, no receiver required?\n\nCyclops Framework was built for these types of situations.  Usage should lead to greater flexibility with less code written.",
   "unity": "2021.3",


### PR DESCRIPTION
- Added the missing 0.8.0 change log.
- Fixed an issue with AnimationState in CyclopsAnimation where it was possible for AnimationState.speed to remain altered past its relationship with CyclopsAnimation.
- Fixed a theorectical domain reloading issue with CyclopsRoutine's use of a static CyclopsPool. Even if domain reloading is disabled, the pool will still be properly reset.